### PR TITLE
updating the version before to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "fbt-cra-typescript-installer",
   "version": "0.0.8",
   "description": "Installer for the FBT API within CRA and TypeScript environments.",
-  "scripts": {},
+  "scripts": {
+    "postinstall": "cd ../../; yarn run fbt-cra-ts-install"
+  },
   "bin": {
     "fbt-cra-ts-install": "./postinstall.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fbt-cra-typescript-installer",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Installer for the FBT API within CRA and TypeScript environments.",
   "scripts": {},
   "bin": {


### PR DESCRIPTION
I need to update the version number before to run 'npm publish', this will update the default package version here: 
https://www.npmjs.com/package/fbt-cra-typescript-installer

Also, I'm making the install command run right after installing.
